### PR TITLE
Feat/docker

### DIFF
--- a/.docker/Dockerfile
+++ b/.docker/Dockerfile
@@ -1,0 +1,18 @@
+FROM debian:trixie AS edk2-builder
+
+# Update package list and install necessary packages
+RUN apt update -y && \
+    apt install -y pip git mono-devel build-essential nuget uuid-dev iasl nasm gcc-aarch64-linux-gnu gcc-arm-linux-gnueabihf python3 python3-distutils python3-git python3-pip gettext locales gnupg ca-certificates python3-venv git-core clang llvm curl python-is-python3 device-tree-compiler adb fastboot
+
+# Create an executable bash script /runasuser.sh
+COPY ./runasuser.sh /runasuser.sh
+
+RUN chmod +x /runasuser.sh
+
+WORKDIR /app
+
+# Label the image
+LABEL maintainer="Dani Ash <d4n1.551@gmail.com>" \
+      description="Image for EDK2 development with necessary tools" \
+      version="latest" \
+      edk2-builder="latest"

--- a/.docker/runasuser.sh
+++ b/.docker/runasuser.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+set -e
+if [ "$#" -ne 4 ] || [ "$1" != "--uid" ] || [ "$3" != "--command" ]; then
+  echo "Usage: /runasuser.sh --uid <uid> --command <command>"
+  exit 1
+fi
+uid=$2
+command=$4
+user=dockeruser
+if id "$uid" &>/dev/null; then
+  user=$(id -nu $uid)
+else
+  adduser --disabled-password --gecos "" --uid $uid $user
+fi
+exec su -c "$command" -s /bin/bash $user

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,17 @@
-FROM debian:trixie AS edk2-builder
+FROM debian:trixie AS mu_builder
 
 # Update package list and install necessary packages
 RUN apt update -y && \
     apt install -y pip git mono-devel build-essential nuget uuid-dev iasl nasm gcc-aarch64-linux-gnu gcc-arm-linux-gnueabihf python3 python3-distutils python3-git python3-pip gettext locales gnupg ca-certificates python3-venv git-core clang llvm curl python-is-python3 device-tree-compiler adb fastboot
 
+RUN ln -s /usr/bin/env /usr/bin/sudo
+
+COPY . /app
+RUN sed -i 's/pip install/pip install --break-system-packages/' /app/setup_env.sh
+RUN /bin/sh -c "cd /app && ./setup_env.sh -p apt"
+
 # Create an executable bash script /runasuser.sh
-COPY ./runasuser.sh /runasuser.sh
+COPY ./.docker/runasuser.sh /runasuser.sh
 
 RUN chmod +x /runasuser.sh
 

--- a/docker-build.sh
+++ b/docker-build.sh
@@ -2,9 +2,11 @@
 
 REPO=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 
-VERSION=$(git --no-pager log -n 1 --pretty=format:"%H" -- Dockerfile)
-IMG_NAME="edk2builder:$VERSION"
+cd $REPO
 
-docker build -t "$IMG_NAME" .docker
+VERSION=$(git --no-pager log -n 1 --pretty=format:"%H" -- .docker/Dockerfile)
+IMG_NAME="mu_builder:$VERSION"
+
+docker build -t "$IMG_NAME" .
 
 docker run --rm -it -v $REPO:/app "$IMG_NAME" /runasuser.sh --uid $(id -u) --command "./build_uefi.sh $@"

--- a/docker-build.sh
+++ b/docker-build.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+REPO=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+
+VERSION=$(git --no-pager log -n 1 --pretty=format:"%H" -- Dockerfile)
+IMG_NAME="edk2builder:$VERSION"
+
+docker build -t "$IMG_NAME" .docker
+
+docker run --rm -it -v $REPO:/app "$IMG_NAME" /runasuser.sh --uid $(id -u) --command "./build_uefi.sh $@"


### PR DESCRIPTION
### What Changed

Added docker build support
Preserves the permissions of the repo to be as less intrusive as possible

builds in docker can be done by running `./docker.build.sh "[argumenrs]"` (yes, the arguments need to be in quotes)
for example, this command `./build_uefi.sh -d kebab -r DEBUG -m 12` turns into `./docker-build.sh -d kebab -r DEBUG -m 12`

### Reason

Making builds simpler

### Checklist

* [x] Is what you changed Tested?
Tested by running the build for kebab
