### PR TITLE
Fix docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:trixie AS mu_builder
+FROM debian:bookworm AS mu_builder
 
 # Update package list and install necessary packages
 RUN apt update -y && \


### PR DESCRIPTION
### What Changed

Changed debian trixy to bookworm in Dockerfile

### Reason

Debian trixy doesn't have adb, fastboot and nuget packages

### Checklist

* [ ] Is what you changed Tested? - yes
